### PR TITLE
Configure renovate_bot to update docker base image automatically.

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:base",
+    "workarounds:supportRedHatImageVersion"
+  ],
+  "enabledManagers": ["dockerfile"],
+  "packageRules": [
+    {
+      "description": "Enable automerge (no PR) for non-major updates.",
+      "automerge": true,
+      "matchUpdateTypes": ["patch", "minor"]
+    }
+  ],
+  "schedule": [
+    "before 4am"
+  ]
+}

--- a/renovate.json
+++ b/renovate.json
@@ -2,16 +2,11 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base",
-    "workarounds:supportRedHatImageVersion"
+    "workarounds:supportRedHatImageVersion",
+    ":automergeMinor"
   ],
   "enabledManagers": ["dockerfile"],
-  "packageRules": [
-    {
-      "description": "Enable automerge (no PR) for non-major updates.",
-      "automerge": true,
-      "matchUpdateTypes": ["patch", "minor"]
-    }
-  ],
+  "automergeType": "branch",
   "schedule": [
     "before 4am"
   ]


### PR DESCRIPTION
Configures renovate bot to automatically update Dockerfile base image version tag. I messed around with this for a while in another repo, this should do the trick for our setup here.

- **Minor** and **Patch** versions will merge change without a PR automatically.
- **Major** versions will open a PR.  (if this annoying can disable this a couple different ways.)
- In theory we shouldn't be getting emails/spam from this, but if something comes up we should be able to turn it off, seems very configurable. 

**Note on redhat versioning:**
Using redhat version preset which uses custom regex to match version as RH does not use standard semver on docker images. Not totally clear if this is actually impacting behavior here, but this preset is intended for use with images we're using, [among other redhat docker images.](https://github.com/Churro/renovate/blob/25dd94a67917c9298568e8db34bc1560ce16182c/lib/config/presets/internal/workarounds.ts#L93).

**To Enable**
Add renovate_bot github app and enable for this repository. 
(If we have issues with CI jobs reporting errors, may need to add ignore tests, but will start without it.)